### PR TITLE
initial commit and push

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Merrick Fox
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Merrick Fox
+Copyright (c) 2015 Bloom&Wild
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# angular-bw-email-autofill
+
+An angular module to add functionality to input fields allowing the user to autocomplete popular email domains.
+
+
+![functionality demo gif](http://i.imgur.com/dbQVO52.gif)
+
+More documentation to follow..

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,17 @@
+{
+  "name": "angular-email-autofill",
+  "version": "0.0.1",
+  "authors": [
+    "Merrick Fox <merrick.fox@gmail.com>"
+  ],
+  "description": "An auto-fill directive for email input boxes, user gets typeahead options in the field for popular email addresses.",
+  "main": "email-autofill.js",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,10 @@
   ],
   "description": "An auto-fill directive for email input boxes, user gets typeahead options in the field for popular email addresses.",
   "main": "email-autofill.js",
+  "dependencies": {
+    "lodash": "latest",
+    "angular": "~1.3.x"
+  },
   "license": "MIT",
   "ignore": [
     "**/.*",

--- a/email-autofill.js
+++ b/email-autofill.js
@@ -1,5 +1,5 @@
 'use strict';
-var emailAutofill = angular.module('emailAutofill', []);
+var emailAutofill = angular.module('bw-emailAutofill', []);
 
 emailAutofill.directive('emailTypeahead', function ($compile, typeahead) {
   return {

--- a/email-autofill.js
+++ b/email-autofill.js
@@ -1,0 +1,232 @@
+'use strict';
+var emailAutofill = angular.module('emailAutofill', []);
+
+emailAutofill.directive('emailTypeahead', function ($compile, typeahead) {
+  return {
+    restrict: 'A',
+    require: 'ngModel',
+    compile: function (element) {
+      element.after('<input type="text" name="hint" readonly="readonly" ng-model="typeaheadHint" class="typeahead-hint">');
+
+      return function(scope, element, attr, ngModel) {
+        var onEmailUpdated;
+        var suggestedEmail;
+
+        element.bind('keydown', function (event) {
+          if((event.which === 13 || event.which === 9) && suggestedEmail) {
+            ngModel.$setViewValue(suggestedEmail);
+            ngModel.$render();
+          }
+        });
+
+        element.bind('blur', function (event) {
+          scope.typeaheadHint = '';
+          scope.$apply();
+        });
+
+        element.bind('focus', function (event) {
+          onEmailUpdated(ngModel.$viewValue);
+          scope.$apply();
+        });
+
+        onEmailUpdated = function (email) {
+          if (email) {
+            var currentlyTypedDomain;
+            var hint;
+            var suggestion;
+            var emailDomainRegex = /.*@(.*)/;
+            var domainMatches = emailDomainRegex.exec(email);
+            var readyToSuggest = (email.indexOf('@') > -1);
+
+            if (readyToSuggest) {
+              currentlyTypedDomain = domainMatches[1];
+              suggestion = typeahead.getSuggestion(currentlyTypedDomain);
+              hint = (suggestion) ? suggestion.substr(currentlyTypedDomain.length) : '';
+              suggestedEmail = email + hint;
+              scope.typeaheadHint = suggestedEmail;
+            } else {
+              scope.typeaheadHint = '';
+              suggestedEmail = undefined;
+            }
+          }
+        };
+
+        scope.$watch(function () {return ngModel.$viewValue;}, onEmailUpdated);
+      };
+    }
+  };
+});
+
+emailAutofill.factory('typeahead', function () {
+  var emailList = [ //priority order!!
+    'gmail.com',
+    'yahoo.com',
+    'hotmail.com',
+    'aol.com',
+    'comcast.net',
+    'me.com',
+    'msn.com',
+    'live.com',
+    'sbcglobal.net',
+    'ymail.com',
+    'att.net',
+    'mac.com',
+    'cox.net',
+    'verizon.net',
+    'hotmail.co.uk',
+    'rocketmail.com',
+    'aim.com',
+    'yahoo.co.uk',
+    'earthlink.net',
+    'charter.net',
+    'optonline.net',
+    'shaw.ca',
+    'yahoo.ca',
+    'googlemail.com',
+    'mail.com',
+    'qq.com',
+    'btinternet.com',
+    'mail.ru',
+    'live.co.uk',
+    'naver.com',
+    'rogers.com',
+    'juno.com',
+    'yahoo.com.tw',
+    'live.ca',
+    'walla.com',
+    '163.com',
+    'roadrunner.com',
+    'telus.net',
+    'embarqmail.com',
+    'hotmail.fr',
+    'pacbell.net',
+    'sky.com',
+    'sympatico.ca',
+    'cfl.rr.com',
+    'tampabay.rr.com',
+    'q.com',
+    'yahoo.co.in',
+    'yahoo.fr',
+    'hotmail.ca',
+    'windstream.net',
+    'hotmail.it',
+    'web.de',
+    'asu.edu',
+    'gmx.de',
+    'gmx.com',
+    'insightbb.com',
+    'netscape.net',
+    'icloud.com',
+    'frontier.com',
+    '126.com',
+    'hanmail.net',
+    'suddenlink.net',
+    'netzero.net',
+    'mindspring.com',
+    'ail.com',
+    'windowslive.com',
+    'netzero.com',
+    'yahoo.com.hk',
+    'yandex.ru',
+    'mchsi.com',
+    'cableone.net',
+    'yahoo.com.cn',
+    'yahoo.es',
+    'yahoo.com.br',
+    'cornell.edu',
+    'ucla.edu',
+    'us.army.mil',
+    'excite.com',
+    'ntlworld.com',
+    'usc.edu',
+    'nate.com',
+    'outlook.com',
+    'nc.rr.com',
+    'prodigy.net',
+    'wi.rr.com',
+    'videotron.ca',
+    'yahoo.it',
+    'yahoo.com.au',
+    'umich.edu',
+    'ameritech.net',
+    'libero.it',
+    'yahoo.de',
+    'rochester.rr.com',
+    'cs.com',
+    'frontiernet.net',
+    'swbell.net',
+    'msu.edu',
+    'ptd.net',
+    'proxymail.facebook.com',
+    'hotmail.es',
+    'austin.rr.com',
+    'nyu.edu',
+    'sina.com',
+    'centurytel.net',
+    'usa.net',
+    'nycap.rr.com',
+    'uci.edu',
+    'hotmail.de',
+    'yahoo.com.sg',
+    'email.arizona.edu',
+    'yahoo.com.mx',
+    'ufl.edu',
+    'bigpond.com',
+    'unlv.nevada.edu',
+    'yahoo.cn',
+    'ca.rr.com',
+    'google.com',
+    'yahoo.co.id',
+    'inbox.com',
+    'fuse.net',
+    'hawaii.rr.com',
+    'talktalk.net',
+    'gmx.net',
+    'walla.co.il',
+    'ucdavis.edu',
+    'carolina.rr.com',
+    'comcast.com',
+    'live.fr',
+    'live.cn',
+    'cogeco.ca',
+    'abv.bg',
+    'tds.net',
+    'centurylink.net',
+    'yahoo.com.vn',
+    'uol.com.br',
+    'osu.edu',
+    'san.rr.com',
+    'rcn.com',
+    'umn.edu',
+    'live.nl',
+    'live.com.au',
+    'tx.rr.com',
+    'eircom.net',
+    'sasktel.net',
+    'post.harvard.edu',
+    'snet.net',
+    'wowway.com',
+    'live.it',
+    'hoteltonight.com',
+    'att.com',
+    'vt.edu',
+    'rambler.ru',
+    'temple.edu',
+    'bloomandwild.com',
+    'cinci.rr.com'
+  ];
+
+  var getSuggestion = function (partialEmail) {
+    if (partialEmail.length === 0) {
+      return emailList[0];
+    } else {
+      return _.find(emailList, function(emailCandidate) {
+        return _.startsWith(emailCandidate, partialEmail);
+      });
+    }
+  };
+
+  return {
+    getSuggestion: getSuggestion
+  };
+});


### PR DESCRIPTION
@kulor @adamdunkley here is the code for the new open source email auto-complete, you can preview the functionality here: http://bw-feature-email-auto-fill.s3-website-eu-west-1.amazonaws.com/send-flowers in the email field.

Documentation to follow, I'll write up a nice readme.
The basic outline is you add the ```email-typeahead``` attribute directive to the input box of your choice, it will create a new DOM input element as a sibling and you use a style (position: absolute; top: 0) to overlay it (this is how everyone else seems to implement this functionality on web), styling will be down to the user and they will also have to specify correct z-indices too. From there the directive is pulling what is already typed, if there is an @ symbol it starts to compare the domain against the list of domains and returns the first one that matches for the first characters typed, it then just displays that in the newly created typeahead input element. There are event listeners for ```tab``` and ```enter``` key, if there is a valid suggestion and either of those keys are pressed it will replace the ng-model of the email input element with the email + the suggestion.