### PR TITLE
fix for people pasting in emails with leading whitespace

### DIFF
--- a/email-autofill.js
+++ b/email-autofill.js
@@ -30,6 +30,8 @@ emailAutofill.directive('emailTypeahead', function ($compile, typeahead) {
         });
 
         onEmailUpdated = function (email) {
+          element.val(email);
+
           if (email) {
             var currentlyTypedDomain;
             var hint;

--- a/email-autofill.js
+++ b/email-autofill.js
@@ -30,7 +30,7 @@ emailAutofill.directive('emailTypeahead', function ($compile, typeahead) {
         });
 
         onEmailUpdated = function (email) {
-          element.val(email);
+          element.val(email); // set input value to ng-model value, helps mitigate whitespace weirdness as model has ng-trim by default
 
           if (email) {
             var currentlyTypedDomain;


### PR DESCRIPTION
The bug is when you paste in an email with leading whitespace like '     someone@google.com' it breaks the ui somewhat. The ng-model for the hint strips out the spaces while the input value retains them. So I am simply setting the input value to the ng-model value which strips the spaces